### PR TITLE
fix: Upated package.json for enabling installation in M1 and beyond

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,4 @@
 {
-  "main": "node_modules/expo/AppEntry.js",
   "scripts": {
     "start": "expo start --dev-client",
     "android": "expo run:android",
@@ -48,7 +47,7 @@
     "axios-mock-adapter": "^1.17.0",
     "babel-plugin-react-intl": "3.0.1",
     "babel-preset-react-native": "^4.0.1",
-    "expo": "^47.0.0",
+    "expo": "~47.0.14",
     "expo-image-picker": "~14.0.1",
     "expo-splash-screen": "~0.17.5",
     "expo-status-bar": "~1.4.2",
@@ -62,9 +61,9 @@
     "react": "18.1.0",
     "react-dom": "18.1.0",
     "react-intl": "2.8.0",
-    "react-native": "0.70.5",
-    "react-native-gesture-handler": "2.8.0",
-    "react-native-reanimated": "2.12.0",
+    "react-native": "0.70.8",
+    "react-native-gesture-handler": "^2.8.0",
+    "react-native-reanimated": "^2.12.0",
     "react-native-safe-area-context": "4.4.1",
     "react-native-screens": "3.18.0",
     "react-native-web": "~0.18.7",
@@ -144,5 +143,7 @@
       "/node_modules/(?!react-native)/.+"
     ]
   },
-  "private": true
+  "private": true,
+  "name": "react-native-template",
+  "version": "1.0.0"
 }


### PR DESCRIPTION
### Ticket Link
---------------------------------------------------


### Related Links
---------------------------------------------------


### Description
**Cocoapods installation issue for M1 and M1 Pro**
---------------------------------------------------


### Steps to Reproduce / Test

1. Clone the react-native-template
2. Execute `yarn`
3. Execute `yarn run ios`
4. This will initiate installation of cocoapods
5. While installing cocoapods it will throw below error


![Screenshot 2024-03-06 at 18 47 43](https://github.com/wednesday-solutions/react-native-template/assets/159783673/7c14b817-6ddd-4de8-b128-1a2222912557)

---------------------------------------------------


### GIF's
---------------------------------------------------
